### PR TITLE
Fix: Correct display of social login button images

### DIFF
--- a/lib/widgets/social_login_buttons.dart
+++ b/lib/widgets/social_login_buttons.dart
@@ -195,18 +195,21 @@ class _SocialButton extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Image.asset(
-                icon,
+              SizedBox(
                 width: 24,
                 height: 24,
-                errorBuilder: (context, error, stackTrace) {
-                  logger.warning('Failed to load social login icon: $icon');
-                  return Icon(
+                child: Image.asset(
+                  icon,
+                  fit: BoxFit.contain,
+                  errorBuilder: (context, error, stackTrace) {
+                    logger.warning('Failed to load social login icon: $icon');
+                    return Icon(
                     Icons.login,
                     size: 24,
                     color: Colors.grey.shade600,
                   );
-                },
+                  },
+                ),
               ),
               const SizedBox(width: 12),
               Text(


### PR DESCRIPTION
The social login buttons for Google and Facebook were not displaying their logos correctly due to fixed image dimensions.

I modified the `_SocialButton` widget in
`lib/widgets/social_login_buttons.dart`:
- Wrapped the `Image.asset` widget with a `SizedBox` of 24x24.
- Removed fixed width and height from `Image.asset`.
- Added `fit: BoxFit.contain` to `Image.asset` to ensure correct aspect ratio and rendering within the button.

Note: I had to skip testing this change due to persistent environment issues that prevented me from building and executing the Flutter application.